### PR TITLE
DM-45416: Fix assorted issues

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,7 +56,7 @@ Science Pipelines (the next section).
 Standalone builds
 #################
 
-A full example setup script is provided in ``setup_conda.sh``.
+A full example setup script is provided in ``setup-conda-release.sh``.
 This defaults to  using ``$CONDA_PREFIX``, but can be configured to output
 elsewhere (e.g. ``~/.local``) like so:
 
@@ -65,7 +65,13 @@ elsewhere (e.g. ``~/.local``) like so:
 Once the build command is run once to create the build directories, subsequent
 rebuilds can use the provided ``build.sh`` script.
 
-Otherwise, to manually create a build directory, call:
+Note that the installation path for the Python bindings' module may not already
+be in Python's sys.path, leading to import errors. This can be solved by
+creating a .pth file. For example, in a conda environment with Python 3.12:
+
+``echo $CONDA_PREFIX/.local/lib/python3.12/site-packages > $CONDA_PREFIX/lib/python3.12/site-packages/conda.pth``
+
+To manually create a build directory, call:
 
 ``meson builddir/``
 

--- a/include/lsst/gauss2d/evaluate.h
+++ b/include/lsst/gauss2d/evaluate.h
@@ -1249,7 +1249,7 @@ std::shared_ptr<Data> make_gaussians_pixel(const std::shared_ptr<const Convolved
         output = std::make_shared<Data>(n_rows, n_cols, nullptr, coordsys);
     }
     auto evaluator
-            = std::make_shared<GaussianEvaluator<T, Data, Indices>>(gaussians, nullptr, nullptr, output);
+            = std::make_unique<GaussianEvaluator<T, Data, Indices>>(gaussians, nullptr, nullptr, output);
     evaluator->loglike_pixel(to_add);
     return output;
 }

--- a/include/lsst/gauss2d/evaluate.h
+++ b/include/lsst/gauss2d/evaluate.h
@@ -867,7 +867,7 @@ public:
             }
         }
     }
-    ~GaussianEvaluator() {};
+    ~GaussianEvaluator() override {};
 
     const Data& IMAGE_NULL_CONST() const { return this->IMAGE_NULL(); };
     const Indices& INDICES_NULL_CONST() const { return this->INDICES_NULL(); };

--- a/python/README.rst
+++ b/python/README.rst
@@ -2,32 +2,21 @@ Gauss2D
 #######
 
 .. todo image:: https://img.shields.io/pypi/v/gauss2d.svg
-   .. todo   :target: https://pypi.python.org/pypi/gauss2d
+.. todo   :target: https://pypi.python.org/pypi/gauss2d
 
 .. todo image:: https://img.shields.io/pypi/pyversions/gauss2d.svg
-   .. todo   :target: https://pypi.python.org/pypi/gauss2d
+.. todo   :target: https://pypi.python.org/pypi/gauss2d
 
 *gauss2d* provides python bindings for the C++ libgauss2d library.
-Python 3.7+, `pybind11 <https://github.com/pybind/pybind11>`_, and numpy are 
-requirements, as numpy arrays are used to store images.
+Python 3.10+, `pybind11 <https://github.com/pybind/pybind11>`_, and numpy are
+requirements, as numpy arrays are used to store images. The library may build
+on Python version as old as 3.8 but these are supported on a best-effort basis.
 
 With libgauss2d installed, these bindings can be built using meson:
 
-meson --prefix=~/.local build && meson compile -C build && meson install -C build
-
-... where the prefix argument is your desired installation path.
-
-You may also need to configure pkg-config, e.g. prepend 
-PKG_CONFIG_PATH=~/.local/lib64/pkgconfig to the build command for a local
-and/or non-root installation.
-
-Alternatively, it can be built for local development using poetry like so:
-
-poetry build && python3 -m pip install .
-
-... using the include pyproject.toml.
+Build scripts are provided in the base directory of gauss2d.
 
 .. todo *gauss2d* is available in `PyPI <https://pypi.python.org/pypi/multiprofit>`_
-   .. and thus can be easily installed via::
+.. and thus can be easily installed via::
 
 .. pip install multiprofit

--- a/python/lib/tests/test_image.cc
+++ b/python/lib/tests/test_image.cc
@@ -66,10 +66,19 @@ TEST_CASE("Mask") {
     auto image = Image(2, 2);
     auto mask = Mask(2, 2);
     mask.fill(false);
-    /*
     CHECK_EQ(mask.get_value_unchecked(0, 0), false);
     mask._get_value_unchecked(1, 1) = true;
-    CHECK(mask.get_value_unchecked(1, 1) == true);
-    CHECK(g2d::images_compatible<double, Image, bool, Mask>(image, mask));
-     */
+    CHECK_EQ(mask.get_value_unchecked(1, 1), true);
+    CHECK_EQ(g2d::images_compatible<double, Image, bool, Mask>(image, mask), true);
+}
+
+TEST_CASE("Evaluate") {
+    auto gauss1 = std::make_shared<g2d::Gaussian>(nullptr, std::make_shared<g2d::Ellipse>(3, 6, 0));
+    auto gauss2 = std::make_shared<g2d::Gaussian>(nullptr, std::make_shared<g2d::Ellipse>(4, 8, 0));
+    auto gauss_conv = std::make_shared<g2d::ConvolvedGaussian>(gauss1, gauss2);
+    g2d::ConvolvedGaussians::Data data{gauss_conv, std::make_shared<g2d::ConvolvedGaussian>(gauss2, gauss1)};
+    auto gaussians_conv = std::make_shared<g2d::ConvolvedGaussians>(data);
+    auto output = g2d::make_gaussians_pixel<double, Image, g2d::python::Image<size_t>>(gaussians_conv,
+                                                                                       nullptr, 5, 7);
+    CHECK_EQ(output->get_n_rows(), 5);
 }


### PR DESCRIPTION
Mostly minor fixes except for the 3.12 segfault, which needs an immediate workaround. The underlying issue is with pybind11 and will be left for [DM-45445](https://rubinobs.atlassian.net/browse/DM-45445).

[DM-45445]: https://rubinobs.atlassian.net/browse/DM-45445?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ